### PR TITLE
send events on user identify()

### DIFF
--- a/extensions/web-tracker/javascript/src/analytics.js-integration-apache-unomi.js
+++ b/extensions/web-tracker/javascript/src/analytics.js-integration-apache-unomi.js
@@ -170,9 +170,7 @@ Unomi.prototype.processReferrer = function() {
  * @param {Identify} identify
  */
 Unomi.prototype.onidentify = function(identify) {
-    console.log('onidentify');
-    console.log(identify);
-    // this.collectEvent(identify.json());
+    this.collectEvent(identify.json());
 };
 
 /**


### PR DESCRIPTION
Events are not sent to unomi when I tried to identify users, code was commented

Snippet that trigger this event:

```
unomiTracker.identify("userId", {
    email: "user@email.com"
});
```